### PR TITLE
update sendTx parameter to use wagmiConfig directly

### DIFF
--- a/javascript/javascript-wagmi/src/services/wallet.js
+++ b/javascript/javascript-wagmi/src/services/wallet.js
@@ -11,10 +11,10 @@ export const signMessage = (provider, address) => {
     })
   }
 
-  export const sendTx = async (provider, address, wagmiAdapter) => {
+  export const sendTx = async (provider, address, wagmiConfig) => {
     if (!provider) return Promise.reject('No provider available')
 
-      const result = await sendTransaction(wagmiAdapter.wagmiConfig, {
+      const result = await sendTransaction(wagmiConfig, {
         to: address,
         value: parseEther("0.0001"),
       })


### PR DESCRIPTION
Fixes the incorrect param in sendTx, wagmiConfig to sendTx is already passed from main.js