### PR TITLE
fix: Solana next-js example 

### DIFF
--- a/nextjs/next-solana-app-router/package.json
+++ b/nextjs/next-solana-app-router/package.json
@@ -12,6 +12,7 @@
     "@reown/appkit": "1.6.8",
     "@reown/appkit-adapter-solana": "1.6.8",
     "@solana/wallet-adapter-wallets": "^0.19.32",
+    "@solana/web3.js": "^1.98.0",
     "next": "15.1.6",
     "react": "19.0.0",
     "react-dom": "19.0.0"


### PR DESCRIPTION
- Add a solana web3.js package to solana next.js example