### PR TITLE
feat: Next.js SIWX multichain own-server example (EVM + Bitcoin + Tron)

### DIFF
--- a/nextjs/next-siwx-multichain-own-server/.env.local.example
+++ b/nextjs/next-siwx-multichain-own-server/.env.local.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_PROJECT_ID=b56e18d47c72ab683b10814fe9495694
+SIWX_SECRET=replace-me-with-a-random-32-byte-hex-string

--- a/nextjs/next-siwx-multichain-own-server/.gitignore
+++ b/nextjs/next-siwx-multichain-own-server/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+.next
+out
+.env
+.env.local
+.env*.local
+*.log
+.DS_Store
+next-env.d.ts

--- a/nextjs/next-siwx-multichain-own-server/README.md
+++ b/nextjs/next-siwx-multichain-own-server/README.md
@@ -1,0 +1,91 @@
+# next-siwx-multichain-own-server
+
+SIWX with **your own Next.js server** as the source of truth for nonces,
+signature verification, and session storage — across **EVM**, **Bitcoin**,
+and **Tron**.
+
+Unlike `DefaultSIWX`, no client-side verifiers run. The wallet signs, the
+signature ships to `/api/siwx/verify`, and the server is the only thing
+that ever checks it.
+
+## How it works
+
+```
+ ┌────────┐  1. GET /api/siwx/nonce            ┌─────────────┐
+ │ Wallet │ ───────────────────────────────►   │ Next.js API │
+ │ + dApp │  2. wallet signs SIWX message      │   routes    │
+ │        │  3. POST /api/siwx/verify          │             │
+ │        │      { data, message, signature }  │  - verify   │
+ │        │ ◄──────────────────────────────── │  - issue JWT │
+ └────────┘  4. httpOnly cookie set            └─────────────┘
+```
+
+The client uses a custom `ServerSIWX` class (`src/siwx/ServerSIWX.ts`) that
+implements the `SIWXConfig` **interface** — not the abstract class — so
+nothing in `@reown/appkit-siwx` runs verifiers locally.
+
+Per-chain verification on the server:
+
+| Namespace | Library                  | Used in                          |
+| --------- | ------------------------ | -------------------------------- |
+| `eip155`  | `viem.verifyMessage`     | `src/siwx/verifiers/eip155.ts`   |
+| `bip122`  | `bip322-js`              | `src/siwx/verifiers/bip122.ts`   |
+| `tron`    | `tronweb` `verifyMessageV2` | `src/siwx/verifiers/tron.ts` |
+
+Session storage is a stateless JWT in an `httpOnly` cookie (`jose`).
+Swap `src/lib/server/session.ts` for a DB-backed store if you need
+revocation or per-session metadata.
+
+## Setup
+
+```bash
+cp .env.local.example .env.local
+# edit .env.local — set SIWX_SECRET to a long random string
+pnpm install
+pnpm dev
+```
+
+Open <http://localhost:3000>, connect a wallet, and sign the SIWX message.
+The "Server says" panel reads back what `/api/siwx/sessions` returns.
+
+## Files
+
+```
+src/
+├── app/
+│   ├── api/siwx/
+│   │   ├── nonce/route.ts     # HMAC-signed stateless nonce
+│   │   ├── verify/route.ts    # signature verify + JWT issuance
+│   │   ├── sessions/route.ts  # current session for active wallet
+│   │   └── revoke/route.ts    # clears the cookie
+│   ├── layout.tsx
+│   └── page.tsx
+├── config/index.ts            # WagmiAdapter + BitcoinAdapter + TronAdapter
+├── context/index.tsx          # createAppKit({ siwx: new ServerSIWX() })
+├── siwx/
+│   ├── ServerSIWX.ts          # implements SIWXConfig interface
+│   └── verifiers/             # server-only signature verification
+│       ├── eip155.ts
+│       ├── bip122.ts
+│       ├── tron.ts
+│       └── index.ts
+└── lib/server/
+    ├── env.ts
+    ├── nonce.ts               # HMAC-signed stateless nonces
+    └── session.ts             # jose JWT + httpOnly cookie
+```
+
+## Notes
+
+- `SIWX_SECRET` is used both for nonce HMACs and for signing the session JWT.
+  Use a long, random, high-entropy value and rotate as needed.
+- Tron signs with the `"TRON Signed Message:"` prefix via `signMessageV2`;
+  recovery uses the matching `verifyMessageV2`.
+- This example keeps a single active session at a time (cookie-based). If you
+  need simultaneous sessions across chains, replace the JWT store with a real
+  database keyed by `(chainId, address)`.
+
+## Resources
+
+- [AppKit SIWX docs](https://docs.reown.com/appkit/authentication/siwx/default)
+- [Reown Dashboard](https://dashboard.reown.com)

--- a/nextjs/next-siwx-multichain-own-server/next.config.ts
+++ b/nextjs/next-siwx-multichain-own-server/next.config.ts
@@ -1,0 +1,10 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  webpack: config => {
+    config.externals.push('pino-pretty', 'lokijs', 'encoding')
+    return config
+  }
+};
+
+export default nextConfig;

--- a/nextjs/next-siwx-multichain-own-server/package.json
+++ b/nextjs/next-siwx-multichain-own-server/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "next-siwx-multichain-own-server",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@react-native-async-storage/async-storage": "^2.2.0",
+    "@reown/appkit": "1.8.20",
+    "@reown/appkit-adapter-bitcoin": "1.8.20",
+    "@reown/appkit-adapter-tron": "1.8.20",
+    "@reown/appkit-adapter-wagmi": "1.8.20",
+    "@reown/appkit-controllers": "1.8.20",
+    "@reown/appkit-siwx": "1.8.20",
+    "@tanstack/react-query": "^5.64.2",
+    "@tronweb3/tronwallet-adapter-tronlink": "^1.1.8",
+    "@wagmi/connectors": "^6.2.0",
+    "bip322-js": "^2.0.0",
+    "jose": "^5.9.6",
+    "next": "15.5.18",
+    "react": "19.2.1",
+    "react-dom": "19.2.1",
+    "tronweb": "^6.0.0",
+    "viem": "^2.47.0",
+    "wagmi": "^2.18.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/react": "19.0.0",
+    "@types/react-dom": "19.0.0",
+    "eslint": "^8",
+    "eslint-config-next": "15.0.3",
+    "typescript": "^5"
+  }
+}

--- a/nextjs/next-siwx-multichain-own-server/src/app/api/siwx/nonce/route.ts
+++ b/nextjs/next-siwx-multichain-own-server/src/app/api/siwx/nonce/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { issueNonce } from "@/lib/server/nonce";
+
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest) {
+  const chainId = req.nextUrl.searchParams.get("chainId");
+  const address = req.nextUrl.searchParams.get("address");
+
+  if (!chainId || !address) {
+    return NextResponse.json(
+      { error: "chainId and address are required" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const nonce = issueNonce(chainId, address);
+    return NextResponse.json({ nonce });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Failed to issue nonce";
+    console.error("[siwx/nonce]", message);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/nextjs/next-siwx-multichain-own-server/src/app/api/siwx/revoke/route.ts
+++ b/nextjs/next-siwx-multichain-own-server/src/app/api/siwx/revoke/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+import { clearSessionCookie } from "@/lib/server/session";
+
+export const runtime = "nodejs";
+
+export async function POST() {
+  await clearSessionCookie();
+  return NextResponse.json({ ok: true });
+}

--- a/nextjs/next-siwx-multichain-own-server/src/app/api/siwx/sessions/route.ts
+++ b/nextjs/next-siwx-multichain-own-server/src/app/api/siwx/sessions/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+import { readSession } from "@/lib/server/session";
+
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest) {
+  let session: Awaited<ReturnType<typeof readSession>>;
+  try {
+    session = await readSession();
+  } catch (err) {
+    console.error("[siwx/sessions]", err);
+    return NextResponse.json({ sessions: [] });
+  }
+  if (!session) return NextResponse.json({ sessions: [] });
+
+  const chainId = req.nextUrl.searchParams.get("chainId");
+  const address = req.nextUrl.searchParams.get("address");
+
+  if (chainId && session.chainId !== chainId) {
+    return NextResponse.json({ sessions: [] });
+  }
+  if (
+    address &&
+    session.address.toLowerCase() !== address.toLowerCase()
+  ) {
+    return NextResponse.json({ sessions: [] });
+  }
+
+  return NextResponse.json({
+    sessions: [
+      {
+        data: {
+          accountAddress: session.address,
+          chainId: session.chainId,
+        },
+        message: session.message,
+        signature: session.signature,
+      },
+    ],
+  });
+}

--- a/nextjs/next-siwx-multichain-own-server/src/app/api/siwx/verify/route.ts
+++ b/nextjs/next-siwx-multichain-own-server/src/app/api/siwx/verify/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyNonce } from "@/lib/server/nonce";
+import { setSessionCookie } from "@/lib/server/session";
+import { verifyForChain } from "@/siwx/verifiers";
+
+export const runtime = "nodejs";
+
+interface VerifyBody {
+  data: {
+    accountAddress: string;
+    chainId: string;
+    nonce: string;
+  };
+  message: string;
+  signature: string;
+}
+
+export async function POST(req: NextRequest) {
+  let body: VerifyBody;
+  try {
+    body = (await req.json()) as VerifyBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const { data, message, signature } = body;
+  const missing: string[] = [];
+  if (!data?.accountAddress) missing.push("data.accountAddress");
+  if (!data?.chainId) missing.push("data.chainId");
+  if (!data?.nonce) missing.push("data.nonce");
+  if (!message) missing.push("message");
+  if (!signature) missing.push("signature");
+  if (missing.length) {
+    console.warn("[siwx/verify] missing fields:", missing, "received:", {
+      hasData: !!data,
+      dataKeys: data ? Object.keys(data) : [],
+      messageLen: message?.length,
+      signatureLen: signature?.length,
+    });
+    return NextResponse.json(
+      { error: `Missing fields: ${missing.join(", ")}` },
+      { status: 400 },
+    );
+  }
+
+  try {
+    if (!verifyNonce(data.nonce, data.chainId, data.accountAddress)) {
+      return NextResponse.json(
+        { error: "Invalid or expired nonce" },
+        { status: 401 },
+      );
+    }
+
+    const ok = await verifyForChain(data.chainId, {
+      message,
+      signature,
+      address: data.accountAddress,
+    });
+
+    if (!ok) {
+      return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+    }
+
+    await setSessionCookie({
+      chainId: data.chainId,
+      address: data.accountAddress,
+      message,
+      signature,
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Verify failed";
+    console.error("[siwx/verify]", message);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/nextjs/next-siwx-multichain-own-server/src/app/globals.css
+++ b/nextjs/next-siwx-multichain-own-server/src/app/globals.css
@@ -1,0 +1,113 @@
+:root {
+  --background: #ffffff;
+  --foreground: #171717;
+}
+
+html,
+body {
+  max-width: 100vw;
+  overflow-x: hidden;
+}
+
+body {
+  color: var(--foreground);
+  background: var(--background);
+  font-family: Arial, Helvetica, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+* {
+  box-sizing: border-box;
+  padding: 0;
+  margin: 0;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+@media (prefers-color-scheme: dark) {
+  html {
+    color-scheme: dark;
+  }
+}
+
+section {
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 13px;
+  margin: 10px;
+  background-color: #f9f9f9;
+  width: 90%;
+  text-align: left;
+}
+
+.pages {
+  align-items: center;
+  justify-items: center;
+  text-align: center;
+}
+
+button {
+  padding: 10px 15px;
+  background-color: white;
+  color: black;
+  border: 2px solid black;
+  border-radius: 6px;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  margin: 15px;
+}
+
+button:hover {
+  background-color: black;
+  color: white;
+}
+
+button:active {
+  background-color: #333;
+  color: white;
+}
+
+h1 {
+  margin: 20px;
+}
+
+pre {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  word-break: break-all;
+}
+
+.link-button {
+  background-color: black;
+  color: white;
+  padding: 5px 10px;
+  text-decoration: none;
+  border-radius: 5px;
+}
+
+.link-button:hover {
+  background-color: white;
+  color: black;
+}
+
+.advice {
+  text-align: center;
+  margin-bottom: 10px;
+  line-height: 25px;
+}
+
+.badge-ok {
+  color: #0a7c2f;
+  font-weight: 600;
+}
+
+.badge-bad {
+  color: #b30000;
+  font-weight: 600;
+}

--- a/nextjs/next-siwx-multichain-own-server/src/app/layout.tsx
+++ b/nextjs/next-siwx-multichain-own-server/src/app/layout.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next";
+
+import "./globals.css";
+import ContextProvider from "@/context";
+
+export const metadata: Metadata = {
+  title: "AppKit SIWX Multichain — Own Server",
+  description: "EVM + Bitcoin + Tron SIWX with your own Next.js server",
+};
+
+export default async function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <body>
+        <ContextProvider>{children}</ContextProvider>
+      </body>
+    </html>
+  );
+}

--- a/nextjs/next-siwx-multichain-own-server/src/app/page.tsx
+++ b/nextjs/next-siwx-multichain-own-server/src/app/page.tsx
@@ -1,0 +1,35 @@
+import { ConnectButton } from "@/components/ConnectButton";
+import { InfoList } from "@/components/InfoList";
+import { ServerSessionInfo } from "@/components/ServerSessionInfo";
+
+export default function Home() {
+  return (
+    <div className="pages">
+      <h1>AppKit SIWX Multichain — Own Server</h1>
+      <p>EVM · Bitcoin · Tron, all verified by this app&apos;s Next.js API routes.</p>
+
+      <ConnectButton />
+
+      <div className="advice">
+        <p>
+          The signature is sent to <code>/api/siwx/verify</code>, verified
+          server-side, and stored as an HTTP-only JWT cookie.
+          <br />
+          Default projectId only works on <code>localhost</code> — get your own at{" "}
+          <a
+            href="https://dashboard.reown.com"
+            target="_blank"
+            className="link-button"
+            rel="noreferrer"
+          >
+            Reown Dashboard
+          </a>
+          .
+        </p>
+      </div>
+
+      <InfoList />
+      <ServerSessionInfo />
+    </div>
+  );
+}

--- a/nextjs/next-siwx-multichain-own-server/src/components/ConnectButton.tsx
+++ b/nextjs/next-siwx-multichain-own-server/src/components/ConnectButton.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+export const ConnectButton = () => {
+  return (
+    <div>
+      <appkit-button />
+    </div>
+  );
+};

--- a/nextjs/next-siwx-multichain-own-server/src/components/InfoList.tsx
+++ b/nextjs/next-siwx-multichain-own-server/src/components/InfoList.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useAppKitAccount, useAppKitNetwork, useAppKitState } from "@reown/appkit/react";
+import { useClientMounted } from "@/hooks/useClientMount";
+
+export const InfoList = () => {
+  const mounted = useClientMounted();
+  const { address, caipAddress, isConnected } = useAppKitAccount();
+  const { caipNetwork } = useAppKitNetwork();
+  const state = useAppKitState();
+
+  if (!mounted) return null;
+
+  return (
+    <>
+      <section>
+        <h2>Wallet</h2>
+        <pre>
+          Connected: {isConnected.toString()}
+          {"\n"}
+          Address: {address}
+          {"\n"}
+          CAIP Address: {caipAddress}
+          {"\n"}
+          Active Chain: {state.activeChain}
+          {"\n"}
+          Network: {caipNetwork?.name}
+        </pre>
+      </section>
+    </>
+  );
+};

--- a/nextjs/next-siwx-multichain-own-server/src/components/ServerSessionInfo.tsx
+++ b/nextjs/next-siwx-multichain-own-server/src/components/ServerSessionInfo.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  useAppKitAccount,
+  useAppKitEvents,
+  useAppKitNetwork,
+} from "@reown/appkit/react";
+import { useClientMounted } from "@/hooks/useClientMount";
+
+interface ServerSession {
+  data: { accountAddress: string; chainId: string };
+}
+
+export const ServerSessionInfo = () => {
+  const mounted = useClientMounted();
+  const { isConnected } = useAppKitAccount();
+  const { caipNetwork } = useAppKitNetwork();
+  const events = useAppKitEvents();
+
+  const [session, setSession] = useState<ServerSession | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/siwx/sessions", { credentials: "include" });
+      const data = (await res.json()) as { sessions: ServerSession[] };
+      setSession(data.sessions?.[0] ?? null);
+    } catch {
+      setSession(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!mounted) return;
+    refresh();
+  }, [mounted, isConnected, caipNetwork?.caipNetworkId, events.data, refresh]);
+
+  if (!mounted) return null;
+
+  return (
+    <section>
+      <h2>Server says</h2>
+      {loading ? (
+        <pre>Loading…</pre>
+      ) : session ? (
+        <pre>
+          <span className="badge-ok">Authenticated</span>
+          {"\n"}
+          Address: {session.data.accountAddress}
+          {"\n"}
+          Chain: {session.data.chainId}
+        </pre>
+      ) : (
+        <pre>
+          <span className="badge-bad">Not authenticated</span>
+        </pre>
+      )}
+      <button onClick={() => refresh()}>Refresh</button>
+    </section>
+  );
+};

--- a/nextjs/next-siwx-multichain-own-server/src/config/index.ts
+++ b/nextjs/next-siwx-multichain-own-server/src/config/index.ts
@@ -1,0 +1,60 @@
+import {
+  bitcoin,
+  bitcoinTestnet,
+  mainnet,
+  sepolia,
+  tronMainnet,
+  tronShastaTestnet,
+} from "@reown/appkit/networks";
+import type { AppKitNetwork } from "@reown/appkit/networks";
+import { BitcoinAdapter } from "@reown/appkit-adapter-bitcoin";
+import { TronAdapter } from "@reown/appkit-adapter-tron";
+import { TronLinkAdapter } from "@tronweb3/tronwallet-adapter-tronlink";
+import { WagmiAdapter } from "@reown/appkit-adapter-wagmi";
+
+export const projectId =
+  process.env.NEXT_PUBLIC_PROJECT_ID || "b56e18d47c72ab683b10814fe9495694";
+
+if (!projectId) {
+  throw new Error("Project ID is not defined");
+}
+
+export const evmNetworks: [AppKitNetwork, ...AppKitNetwork[]] = [
+  mainnet,
+  sepolia,
+];
+
+export const bitcoinNetworks: [AppKitNetwork, ...AppKitNetwork[]] = [
+  bitcoin,
+  bitcoinTestnet,
+];
+
+export const tronNetworks: [AppKitNetwork, ...AppKitNetwork[]] = [
+  tronMainnet,
+  tronShastaTestnet,
+];
+
+export const networks: [AppKitNetwork, ...AppKitNetwork[]] = [
+  ...evmNetworks,
+  ...bitcoinNetworks,
+  ...tronNetworks,
+];
+
+export const wagmiAdapter = new WagmiAdapter({
+  projectId,
+  networks: evmNetworks,
+  ssr: true,
+});
+
+export const bitcoinAdapter = new BitcoinAdapter({
+  projectId,
+});
+
+export const tronAdapter = new TronAdapter({
+  walletAdapters: [
+    new TronLinkAdapter({
+      openUrlWhenWalletNotFound: false,
+      checkTimeout: 3000,
+    }),
+  ],
+});

--- a/nextjs/next-siwx-multichain-own-server/src/context/index.tsx
+++ b/nextjs/next-siwx-multichain-own-server/src/context/index.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import {
+  bitcoinAdapter,
+  networks,
+  projectId,
+  tronAdapter,
+  wagmiAdapter,
+} from "@/config";
+import { ServerSIWX } from "@/siwx/ServerSIWX";
+import { createAppKit } from "@reown/appkit/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React, { useState, type ReactNode } from "react";
+import { WagmiProvider } from "wagmi";
+
+if (!projectId) {
+  throw new Error("Project ID is not defined");
+}
+
+const metadata = {
+  name: "next-siwx-multichain-own-server",
+  description: "SIWX multichain with your own Next.js server",
+  url: "https://reown.com",
+  icons: ["https://avatars.githubusercontent.com/u/179229932"],
+};
+
+export const modal = createAppKit({
+  adapters: [wagmiAdapter, bitcoinAdapter, tronAdapter],
+  projectId,
+  networks,
+  metadata,
+  themeMode: "light",
+  features: {
+    analytics: true,
+    socials: [],
+    email: false,
+  },
+  siwx: new ServerSIWX(),
+});
+
+function ContextProvider({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient());
+
+  return (
+    <WagmiProvider config={wagmiAdapter.wagmiConfig}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </WagmiProvider>
+  );
+}
+
+export default ContextProvider;

--- a/nextjs/next-siwx-multichain-own-server/src/hooks/useClientMount.ts
+++ b/nextjs/next-siwx-multichain-own-server/src/hooks/useClientMount.ts
@@ -1,0 +1,8 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export function useClientMounted() {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  return mounted;
+}

--- a/nextjs/next-siwx-multichain-own-server/src/lib/server/env.ts
+++ b/nextjs/next-siwx-multichain-own-server/src/lib/server/env.ts
@@ -1,0 +1,13 @@
+export function getSecret(): Uint8Array {
+  const secret = process.env.SIWX_SECRET;
+  if (!secret || secret.length < 16) {
+    throw new Error(
+      "SIWX_SECRET is missing or too short. Set it in .env.local (>=16 chars).",
+    );
+  }
+  return new TextEncoder().encode(secret);
+}
+
+export const NONCE_TTL_MS = 5 * 60 * 1000;
+export const SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+export const SESSION_COOKIE = "siwx_session";

--- a/nextjs/next-siwx-multichain-own-server/src/lib/server/nonce.ts
+++ b/nextjs/next-siwx-multichain-own-server/src/lib/server/nonce.ts
@@ -1,0 +1,44 @@
+import { createHmac, randomBytes, timingSafeEqual } from "crypto";
+import { NONCE_TTL_MS } from "./env";
+
+/**
+ * Stateless nonce: `${random}.${exp}.${hmac(random|exp|chainId|address)}`.
+ * Server verifies the HMAC at /verify time without needing a store.
+ */
+export function issueNonce(chainId: string, address: string): string {
+  const random = randomBytes(16).toString("hex");
+  const exp = Date.now() + NONCE_TTL_MS;
+  const sig = signNonce(random, exp, chainId, address);
+  return `${random}.${exp}.${sig}`;
+}
+
+export function verifyNonce(
+  nonce: string,
+  chainId: string,
+  address: string,
+): boolean {
+  const parts = nonce.split(".");
+  if (parts.length !== 3) return false;
+  const [random, expStr, sig] = parts;
+  const exp = Number(expStr);
+  if (!Number.isFinite(exp) || exp < Date.now()) return false;
+
+  const expected = signNonce(random, exp, chainId, address);
+  const a = Buffer.from(sig, "hex");
+  const b = Buffer.from(expected, "hex");
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+function signNonce(
+  random: string,
+  exp: number,
+  chainId: string,
+  address: string,
+): string {
+  const secret = process.env.SIWX_SECRET;
+  if (!secret) throw new Error("SIWX_SECRET is missing");
+  return createHmac("sha256", secret)
+    .update(`${random}|${exp}|${chainId}|${address}`)
+    .digest("hex");
+}

--- a/nextjs/next-siwx-multichain-own-server/src/lib/server/session.ts
+++ b/nextjs/next-siwx-multichain-own-server/src/lib/server/session.ts
@@ -1,0 +1,50 @@
+import { SignJWT, jwtVerify } from "jose";
+import { cookies } from "next/headers";
+import { SESSION_COOKIE, SESSION_TTL_MS, getSecret } from "./env";
+
+export interface SessionPayload {
+  chainId: string;
+  address: string;
+  message: string;
+  signature: string;
+}
+
+export async function setSessionCookie(payload: SessionPayload): Promise<void> {
+  const token = await new SignJWT({ ...payload })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime(Math.floor((Date.now() + SESSION_TTL_MS) / 1000))
+    .sign(getSecret());
+
+  const store = await cookies();
+  store.set(SESSION_COOKIE, token, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: Math.floor(SESSION_TTL_MS / 1000),
+  });
+}
+
+export async function readSession(): Promise<SessionPayload | null> {
+  const store = await cookies();
+  const token = store.get(SESSION_COOKIE)?.value;
+  if (!token) return null;
+
+  try {
+    const { payload } = await jwtVerify(token, getSecret());
+    return {
+      chainId: String(payload.chainId),
+      address: String(payload.address),
+      message: String(payload.message),
+      signature: String(payload.signature),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function clearSessionCookie(): Promise<void> {
+  const store = await cookies();
+  store.delete(SESSION_COOKIE);
+}

--- a/nextjs/next-siwx-multichain-own-server/src/siwx/ServerSIWX.ts
+++ b/nextjs/next-siwx-multichain-own-server/src/siwx/ServerSIWX.ts
@@ -1,0 +1,151 @@
+import type {
+  CaipNetworkId,
+  SIWXConfig,
+  SIWXMessage,
+  SIWXSession,
+} from "@reown/appkit";
+import { ConnectionController } from "@reown/appkit-controllers";
+import { InformalMessenger } from "@reown/appkit-siwx";
+
+const FALLBACK_DOMAIN = "localhost";
+const FALLBACK_URI = "http://localhost";
+
+/**
+ * SIWX implementation that delegates nonce issuance, signature verification,
+ * and session storage to this app's own Next.js API routes.
+ *
+ * Unlike DefaultSIWX, no client-side verifiers run — the server is the only
+ * thing that ever checks signatures.
+ */
+export class ServerSIWX implements SIWXConfig {
+  required = true;
+
+  private readonly messenger: InformalMessenger;
+
+  constructor() {
+    this.messenger = new InformalMessenger({
+      domain: typeof window === "undefined" ? FALLBACK_DOMAIN : window.location.host,
+      uri: typeof window === "undefined" ? FALLBACK_URI : window.location.origin,
+      statement: "Sign in to verify wallet ownership.",
+      getNonce: async ({ accountAddress, chainId }) => {
+        const res = await fetch(
+          `/api/siwx/nonce?chainId=${encodeURIComponent(chainId)}&address=${encodeURIComponent(
+            accountAddress,
+          )}`,
+        );
+        if (!res.ok) throw new Error("Failed to fetch nonce");
+        const { nonce } = (await res.json()) as { nonce: string };
+        return nonce;
+      },
+    });
+  }
+
+  createMessage(input: SIWXMessage.Input): Promise<SIWXMessage> {
+    return this.messenger.createMessage(input);
+  }
+
+  /**
+   * Workaround: AppKit's TronAdapter.signMessage() (adapter.ts:146-148) is
+   * a stub returning ''. We bypass ConnectionController for Tron and call
+   * the injected TronLink (`window.tronWeb.trx.signMessageV2`) directly.
+   * Other namespaces fall through to AppKit's default signer.
+   */
+  async signMessage({
+    message,
+    chainId,
+  }: {
+    message: string;
+    chainId: string;
+    accountAddress: string;
+  }): Promise<string> {
+    if (chainId.startsWith("tron:")) {
+      const trx = (window as unknown as { tronWeb?: { trx?: { signMessageV2?: (m: string) => Promise<string> } } })
+        .tronWeb?.trx;
+      if (!trx?.signMessageV2) {
+        throw new Error(
+          "TronLink not available — window.tronWeb.trx.signMessageV2 missing",
+        );
+      }
+      const signature = await trx.signMessageV2(message);
+      if (!signature) throw new Error("TronLink returned empty signature");
+      return signature;
+    }
+
+    const signature = await ConnectionController.signMessage(message);
+    if (!signature) throw new Error("Wallet returned empty signature");
+    return signature;
+  }
+
+  async addSession(session: SIWXSession): Promise<void> {
+    console.debug("[ServerSIWX.addSession] sending", {
+      dataKeys: Object.keys(session.data ?? {}),
+      data: session.data,
+      messageLen: session.message?.length,
+      signatureLen: session.signature?.length,
+    });
+    const res = await fetch("/api/siwx/verify", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        data: session.data,
+        message: session.message,
+        signature: session.signature,
+      }),
+      credentials: "include",
+    });
+
+    if (!res.ok) {
+      const { error } = await safeJson(res);
+      throw new Error(error || "Failed to verify signature");
+    }
+  }
+
+  async getSessions(
+    chainId: CaipNetworkId,
+    address: string,
+  ): Promise<SIWXSession[]> {
+    const res = await fetch(
+      `/api/siwx/sessions?chainId=${encodeURIComponent(chainId)}&address=${encodeURIComponent(
+        address,
+      )}`,
+      { credentials: "include" },
+    );
+    if (!res.ok) return [];
+    const { sessions } = (await res.json()) as { sessions: SIWXSession[] };
+    return sessions ?? [];
+  }
+
+  async revokeSession(
+    chainId: CaipNetworkId,
+    address: string,
+  ): Promise<void> {
+    await fetch("/api/siwx/revoke", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ chainId, address }),
+      credentials: "include",
+    });
+  }
+
+  async setSessions(sessions: SIWXSession[]): Promise<void> {
+    if (sessions.length === 0) {
+      await fetch("/api/siwx/revoke", { method: "POST", credentials: "include" });
+      return;
+    }
+    for (const session of sessions) {
+      await this.addSession(session);
+    }
+  }
+
+  getRequired() {
+    return this.required;
+  }
+}
+
+async function safeJson(res: Response): Promise<{ error?: string }> {
+  try {
+    return (await res.json()) as { error?: string };
+  } catch {
+    return {};
+  }
+}

--- a/nextjs/next-siwx-multichain-own-server/src/siwx/verifiers/bip122.ts
+++ b/nextjs/next-siwx-multichain-own-server/src/siwx/verifiers/bip122.ts
@@ -1,0 +1,17 @@
+import { Verifier } from "bip322-js";
+
+export async function verifyBip122({
+  message,
+  signature,
+  address,
+}: {
+  message: string;
+  signature: string;
+  address: string;
+}): Promise<boolean> {
+  try {
+    return Verifier.verifySignature(address, message, signature);
+  } catch {
+    return false;
+  }
+}

--- a/nextjs/next-siwx-multichain-own-server/src/siwx/verifiers/eip155.ts
+++ b/nextjs/next-siwx-multichain-own-server/src/siwx/verifiers/eip155.ts
@@ -1,0 +1,21 @@
+import { verifyMessage } from "viem";
+
+export async function verifyEip155({
+  message,
+  signature,
+  address,
+}: {
+  message: string;
+  signature: string;
+  address: string;
+}): Promise<boolean> {
+  try {
+    return await verifyMessage({
+      message,
+      signature: signature as `0x${string}`,
+      address: address as `0x${string}`,
+    });
+  } catch {
+    return false;
+  }
+}

--- a/nextjs/next-siwx-multichain-own-server/src/siwx/verifiers/index.ts
+++ b/nextjs/next-siwx-multichain-own-server/src/siwx/verifiers/index.ts
@@ -1,0 +1,27 @@
+import { verifyBip122 } from "./bip122";
+import { verifyEip155 } from "./eip155";
+import { verifyTron } from "./tron";
+
+export type VerifyInput = {
+  message: string;
+  signature: string;
+  address: string;
+};
+
+export async function verifyForChain(
+  chainId: string,
+  input: VerifyInput,
+): Promise<boolean> {
+  const namespace = chainId.split(":")[0];
+
+  switch (namespace) {
+    case "eip155":
+      return verifyEip155(input);
+    case "bip122":
+      return verifyBip122(input);
+    case "tron":
+      return verifyTron(input);
+    default:
+      return false;
+  }
+}

--- a/nextjs/next-siwx-multichain-own-server/src/siwx/verifiers/tron.ts
+++ b/nextjs/next-siwx-multichain-own-server/src/siwx/verifiers/tron.ts
@@ -1,0 +1,28 @@
+import TronWeb from "tronweb";
+
+/**
+ * Verifies a Tron-signed message and checks that the recovered address
+ * matches the expected base58 address (e.g. `TXyz...`).
+ *
+ * TronLink signs with `tronWeb.trx.signMessageV2`, which uses the
+ * "TRON Signed Message:" prefix. We recover via `verifyMessageV2`.
+ */
+export async function verifyTron({
+  message,
+  signature,
+  address,
+}: {
+  message: string;
+  signature: string;
+  address: string;
+}): Promise<boolean> {
+  try {
+    const recovered: string = await TronWeb.Trx.verifyMessageV2(
+      message,
+      signature,
+    );
+    return recovered === address;
+  } catch {
+    return false;
+  }
+}

--- a/nextjs/next-siwx-multichain-own-server/tsconfig.json
+++ b/nextjs/next-siwx-multichain-own-server/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

Adds `nextjs/next-siwx-multichain-own-server`: a Next.js example that implements the SIWX `SIWXConfig` interface directly (not `DefaultSIWX`), so nonce issuance, signature verification, and session storage all live in this app's own API routes — no client-side verifiers run.

- `/api/siwx/{nonce,verify,sessions,revoke}` with HMAC-signed stateless nonces and a `jose` JWT in an httpOnly cookie.
- Per-chain server verifiers: `viem` (eip155), `bip322-js` (bip122), `tronweb` `verifyMessageV2` (tron).
- `ServerSIWX.signMessage()` works around AppKit 1.8.20's `TronAdapter.signMessage()` stub by calling `window.tronWeb.trx.signMessageV2` directly for Tron; other chains delegate to `ConnectionController` like `DefaultSigner`.

## Test plan

- [ ] cp .env.local.example .env.local and set SIWX_SECRET
- [ ] pnpm install && pnpm dev
- [ ] Connect EVM wallet, sign SIWX message, verify "Server says: Authenticated"
- [ ] Connect Bitcoin wallet, sign, verify
- [ ] Connect Tron (TronLink) wallet, sign, verify
- [ ] Disconnect / refresh and confirm session clears