### PR TITLE
feat: deploy EVM smart account with cheapest tx in react-wagmi

### DIFF
--- a/react/react-wagmi/src/App.tsx
+++ b/react/react-wagmi/src/App.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ActionButtonList } from './components/ActionButtonList'
 import { SmartContractActionButtonList } from './components/SmartContractActionButtonList'
+import { SmartAccountDeployButton } from './components/SmartAccountDeployButton'
 import { InfoList } from './components/InfoList'
 import { projectId, metadata, networks, wagmiAdapter } from './config'
 
@@ -27,6 +28,9 @@ const generalConfig = {
 createAppKit({
   adapters: [wagmiAdapter],
   ...generalConfig,
+  // Use a Smart Account (ERC-4337) by default for the embedded wallet on EVM.
+  // The smart account contract is deployed on-chain on its first transaction.
+  defaultAccountTypes: { eip155: 'smartAccount' },
   features: {
     analytics: true // Optional - defaults to your Cloud configuration
   }
@@ -59,6 +63,7 @@ export function App() {
             <appkit-button />
             <ActionButtonList sendHash={receiveHash} sendSignMsg={receiveSignedMsg} sendBalance={receivebalance}/>
             <SmartContractActionButtonList />
+            <SmartAccountDeployButton />
             <div className="advice">
               <p>
                 This projectId only works on localhost. <br/>

--- a/react/react-wagmi/src/components/SmartAccountDeployButton.tsx
+++ b/react/react-wagmi/src/components/SmartAccountDeployButton.tsx
@@ -1,0 +1,94 @@
+//
+// Deploys an AppKit Smart Account (ERC-4337) with the cheapest possible transaction.
+//
+// A smart account contract is only deployed on-chain on its FIRST transaction.
+// The cheapest way to trigger that deployment is a 0-value transaction sent to
+// the account's own address (a no-op self-transfer). The bundler bundles the
+// account-deployment together with this empty call, so you only pay for the
+// deployment itself.
+//
+
+import { useEffect } from 'react'
+import { useAppKitAccount, useAppKitNetwork } from '@reown/appkit/react'
+import { useBytecode, useSendTransaction, useWaitForTransactionReceipt } from 'wagmi'
+import type { Address } from 'viem'
+
+export const SmartAccountDeployButton = () => {
+  const { address, isConnected, embeddedWalletInfo } = useAppKitAccount()
+  const { chainId } = useAppKitNetwork()
+
+  // A smart account is "deployed" once there is bytecode at its address.
+  const { data: bytecode, isLoading: isCheckingDeployment, refetch: refetchBytecode } =
+    useBytecode({
+      address: address as Address,
+      query: { enabled: Boolean(address) },
+    })
+
+  const { data: hash, sendTransaction, isPending, error } = useSendTransaction()
+  const { isLoading: isConfirming, isSuccess: isConfirmed } = useWaitForTransactionReceipt({ hash })
+
+  const isSmartAccount = embeddedWalletInfo?.accountType === 'smartAccount'
+  const isDeployed = Boolean(bytecode && bytecode !== '0x')
+
+  // Once the deployment tx is confirmed, re-check the bytecode so the UI updates.
+  useEffect(() => {
+    if (isConfirmed) {
+      refetchBytecode()
+    }
+  }, [isConfirmed, refetchBytecode])
+
+  // The cheapest deployment trigger: a 0-value, empty-data tx to the account itself.
+  const handleDeploy = () => {
+    if (!address) return
+    sendTransaction({
+      to: address as Address,
+      value: 0n,
+    })
+  }
+
+  // Only relevant for EVM smart accounts that are not yet deployed.
+  if (!isConnected || !isSmartAccount) {
+    return null
+  }
+
+  return (
+    <section>
+      <h2>Smart Account Deployment</h2>
+      <pre>
+        Address: {address}<br />
+        Network (chainId): {chainId?.toString()}<br />
+        Deployed: {isCheckingDeployment ? 'checking…' : isDeployed.toString()}<br />
+      </pre>
+
+      {isDeployed ? (
+        <p>✅ Your smart account is already deployed on this network.</p>
+      ) : (
+        <>
+          <p>
+            Your smart account is not deployed yet on this network. Deploy it with
+            the cheapest possible transaction (a 0-value self-transfer).
+          </p>
+          <button onClick={handleDeploy} disabled={isPending || isConfirming}>
+            {isPending
+              ? 'Confirm in wallet…'
+              : isConfirming
+                ? 'Deploying…'
+                : 'Deploy Smart Account (cheapest tx)'}
+          </button>
+        </>
+      )}
+
+      {hash && (
+        <pre>
+          Tx Hash: {hash}<br />
+          {isConfirming && 'Waiting for confirmation…'}
+          {isConfirmed && '✅ Smart account deployed!'}
+        </pre>
+      )}
+
+      {error && (
+        <pre>Error: {error.message}</pre>
+      )}
+    </section>
+  )
+}

--- a/react/react-wagmi/src/config/index.tsx
+++ b/react/react-wagmi/src/config/index.tsx
@@ -17,7 +17,7 @@ export const metadata = {
   }
 
 // for custom networks visit -> https://docs.reown.com/appkit/react/core/custom-networks
-export const networks = [mainnet, arbitrum, sepolia,p olygon, base] as [AppKitNetwork, ...AppKitNetwork[]]
+export const networks = [mainnet, arbitrum, sepolia, polygon, base] as [AppKitNetwork, ...AppKitNetwork[]]
 
 //Set up the Wagmi Adapter (Config)
 export const wagmiAdapter = new WagmiAdapter({

--- a/react/react-wagmi/src/config/index.tsx
+++ b/react/react-wagmi/src/config/index.tsx
@@ -1,5 +1,5 @@
 import { WagmiAdapter } from '@reown/appkit-adapter-wagmi'
-import { mainnet, arbitrum, sepolia } from '@reown/appkit/networks'
+import { mainnet, arbitrum, sepolia,polygon } from '@reown/appkit/networks'
 import type { AppKitNetwork } from '@reown/appkit/networks'
 
 // Get projectId from https://dashboard.reown.com
@@ -17,7 +17,7 @@ export const metadata = {
   }
 
 // for custom networks visit -> https://docs.reown.com/appkit/react/core/custom-networks
-export const networks = [mainnet, arbitrum, sepolia] as [AppKitNetwork, ...AppKitNetwork[]]
+export const networks = [mainnet, arbitrum, sepolia,polygon] as [AppKitNetwork, ...AppKitNetwork[]]
 
 //Set up the Wagmi Adapter (Config)
 export const wagmiAdapter = new WagmiAdapter({

--- a/react/react-wagmi/src/config/index.tsx
+++ b/react/react-wagmi/src/config/index.tsx
@@ -1,5 +1,5 @@
 import { WagmiAdapter } from '@reown/appkit-adapter-wagmi'
-import { mainnet, arbitrum, sepolia,polygon } from '@reown/appkit/networks'
+import { mainnet, arbitrum, sepolia, polygon, base } from '@reown/appkit/networks'
 import type { AppKitNetwork } from '@reown/appkit/networks'
 
 // Get projectId from https://dashboard.reown.com
@@ -17,7 +17,7 @@ export const metadata = {
   }
 
 // for custom networks visit -> https://docs.reown.com/appkit/react/core/custom-networks
-export const networks = [mainnet, arbitrum, sepolia,polygon] as [AppKitNetwork, ...AppKitNetwork[]]
+export const networks = [mainnet, arbitrum, sepolia,p olygon, base] as [AppKitNetwork, ...AppKitNetwork[]]
 
 //Set up the Wagmi Adapter (Config)
 export const wagmiAdapter = new WagmiAdapter({


### PR DESCRIPTION
Adds a flow to the `react/react-wagmi` example for a connected EVM smart-account user to deploy their account on-chain. A smart account (ERC-4337) is only deployed on its first transaction, so the new `SmartAccountDeployButton` triggers deployment with the cheapest possible tx — a 0-value self-transfer. It detects whether the account is already deployed via `useBytecode` and shows the button only when the account type is `smartAccount` and not yet deployed. `App.tsx` now sets `defaultAccountTypes: { eip155: 'smartAccount' }` so the embedded wallet uses a smart account on EVM by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)