### PR TITLE
docs: fix dead documentation links and add JavaScript example READMEs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi viem @tanstack/react
 import { WagmiAdapter } from '@reown/appkit-adapter-wagmi'
 import { mainnet, arbitrum } from '@reown/appkit/networks'
 
-const projectId = 'YOUR_PROJECT_ID' // Get from https://cloud.reown.com
+const projectId = 'YOUR_PROJECT_ID' // Get from https://dashboard.reown.com/
 
 export const networks = [mainnet, arbitrum]
 

--- a/README.md
+++ b/README.md
@@ -13,23 +13,15 @@ This repository provides examples of how to integrate and use **AppKit** in vari
 
 - **Universal Authentication**  
   Support for email, social logins, and one-click authentication using SIWX, enabling seamless user access across EVM, Solana, and Bitcoin networks.  
-  [Read more →](https://docs.reown.com/appkit/features/authentication)
+  [Read more →](https://docs.reown.com/appkit/authentication/socials)
 
 - **Smart Accounts**  
   Enhance user security and convenience with multi-signature authorization and automated transaction workflows.  
   [Read more →](https://docs.reown.com/appkit/features/smart-accounts)
 
-- **Smart Sessions**  
-  Enable dApps to perform specific blockchain actions on behalf of users for a defined period, eliminating the need for repeated approvals.  
-  [Read more →](https://docs.reown.com/appkit/features/smart-sessions)
-
 - **On-Ramp & Swaps**  
   Let users buy crypto and swap tokens directly within your app.  
   [Read more →](https://docs.reown.com/appkit/features/onramp)
-
-- **Notifications**  
-  Deliver important updates directly to users’ wallets or in-app using Web3-native notifications.  
-  [Read more →](https://docs.reown.com/appkit/next/notifications/overview)
 
 - **Multi-Chain Support**  
   Works seamlessly with EVM chains, Solana, and Bitcoin.  
@@ -68,7 +60,6 @@ Each framework has examples for the implementation with wagmi, ethers, solana, b
 |           | Solana        | [Demo](https://appkit-web-examples-react-solana.reown.com/)                                  | [Fork](https://stackblitz.com/github/reown-com/appkit-web-examples/tree/main/react/react-solana/)              |
 |           | Bitcoin       | [Demo](https://appkit-web-examples-react-bitcoin.reown.com/)                                 | [Fork](https://stackblitz.com/github/reown-com/appkit-web-examples/tree/main/react/react-bitcoin/)             |
 |           | Multichain    | [Demo](https://appkit-web-examples-react-multichain.reown.com/)                              | [Fork](https://stackblitz.com/github/reown-com/appkit-web-examples/tree/main/react/react-multichain/)          |
-|           | AppKit Pay    | [Demo](https://appkit-web-examples-pay.reown.com/)                                           | [Fork](https://stackblitz.com/github/reown-com/appkit-web-examples/tree/main/react/react-wagmi-appkit-pay/)          |
 | **Vue**    | ethers        | [Demo](https://appkit-web-examples-vue-ethers.reown.com/)                                    | [Fork](https://stackblitz.com/github/reown-com/appkit-web-examples/tree/main/vue/vue-ethers/)                  |
 |           | wagmi         | [Demo](https://appkit-web-examples-vue-wagmi.reown.com/)                                     | [Fork](https://stackblitz.com/github/reown-com/appkit-web-examples/tree/main/vue/vue-wagmi/)                   |
 |           | Solana        | [Demo](https://appkit-web-examples-vue-solana.reown.com/)                                    | [Fork](https://stackblitz.com/github/reown-com/appkit-web-examples/tree/main/vue/vue-solana/)                  |
@@ -108,7 +99,6 @@ Each framework has examples for the implementation with wagmi, ethers, solana, b
 ├──────── react-multichain    # Wagmi + Solana
 ├──────── react-solana
 ├──────── react-siwe-server-example
-├──────── react-wagmi-appkit-pay
 ├── vue/      # Web AppKit with Vue
 ├──────── vue-bitcoin    
 ├──────── vue-core    # AppKit Core

--- a/javascript/javascript-bitcoin/.env.example
+++ b/javascript/javascript-bitcoin/.env.example
@@ -1,0 +1,1 @@
+VITE_PROJECT_ID=

--- a/javascript/javascript-bitcoin/README.md
+++ b/javascript/javascript-bitcoin/README.md
@@ -1,0 +1,18 @@
+# Reown AppKit Example using Bitcoin (Vite + JavaScript)
+
+This is a [Vite](https://vitejs.dev) project using vanilla JavaScript with the Bitcoin adapter.
+
+## Usage
+
+1. Go to [Reown Dashboard](https://dashboard.reown.com) and create a new project.
+2. Copy your `Project ID`
+3. Rename `.env.example` to `.env` and paste your `Project ID` as the value for `VITE_PROJECT_ID`
+4. Run `pnpm install` to install dependencies
+5. Run `pnpm run dev` to start the development server
+6. Test it at https://react-wallet.reown.com/
+
+## Resources
+
+- [Reown — Docs](https://docs.reown.com)
+- [Vite — GitHub](https://github.com/vitejs/vite)
+- [Vite — Docs](https://vitejs.dev/guide/)

--- a/javascript/javascript-core-universal-connector/.env.example
+++ b/javascript/javascript-core-universal-connector/.env.example
@@ -1,0 +1,1 @@
+VITE_PROJECT_ID=

--- a/javascript/javascript-core-universal-provider-sui/.env.example
+++ b/javascript/javascript-core-universal-provider-sui/.env.example
@@ -1,0 +1,1 @@
+VITE_PROJECT_ID=

--- a/javascript/javascript-core/.env.example
+++ b/javascript/javascript-core/.env.example
@@ -1,0 +1,1 @@
+VITE_PROJECT_ID=

--- a/javascript/javascript-core/README.md
+++ b/javascript/javascript-core/README.md
@@ -1,0 +1,18 @@
+# Reown AppKit Core Example (Vite + JavaScript)
+
+This is a [Vite](https://vitejs.dev) project using vanilla JavaScript with AppKit Core (chain-agnostic, no blockchain adapter).
+
+## Usage
+
+1. Go to [Reown Dashboard](https://dashboard.reown.com) and create a new project.
+2. Copy your `Project ID`
+3. Rename `.env.example` to `.env` and paste your `Project ID` as the value for `VITE_PROJECT_ID`
+4. Run `pnpm install` to install dependencies
+5. Run `pnpm run dev` to start the development server
+6. Test it at https://react-wallet.reown.com/
+
+## Resources
+
+- [Reown — Docs](https://docs.reown.com)
+- [Vite — GitHub](https://github.com/vitejs/vite)
+- [Vite — Docs](https://vitejs.dev/guide/)

--- a/javascript/javascript-ethers/.env.example
+++ b/javascript/javascript-ethers/.env.example
@@ -1,0 +1,1 @@
+VITE_PROJECT_ID=

--- a/javascript/javascript-ethers/README.md
+++ b/javascript/javascript-ethers/README.md
@@ -1,0 +1,18 @@
+# Reown AppKit Example using Ethers (Vite + JavaScript)
+
+This is a [Vite](https://vitejs.dev) project using vanilla JavaScript with the Ethers.js v6 adapter.
+
+## Usage
+
+1. Go to [Reown Dashboard](https://dashboard.reown.com) and create a new project.
+2. Copy your `Project ID`
+3. Rename `.env.example` to `.env` and paste your `Project ID` as the value for `VITE_PROJECT_ID`
+4. Run `pnpm install` to install dependencies
+5. Run `pnpm run dev` to start the development server
+6. Test it at https://react-wallet.reown.com/
+
+## Resources
+
+- [Reown — Docs](https://docs.reown.com)
+- [Vite — GitHub](https://github.com/vitejs/vite)
+- [Vite — Docs](https://vitejs.dev/guide/)

--- a/javascript/javascript-multichain/.env.example
+++ b/javascript/javascript-multichain/.env.example
@@ -1,0 +1,1 @@
+VITE_PROJECT_ID=

--- a/javascript/javascript-multichain/README.md
+++ b/javascript/javascript-multichain/README.md
@@ -1,0 +1,18 @@
+# Reown AppKit Example using Multichain (Vite + JavaScript)
+
+This is a [Vite](https://vitejs.dev) project using vanilla JavaScript with the wagmi (EVM) and Solana adapters together.
+
+## Usage
+
+1. Go to [Reown Dashboard](https://dashboard.reown.com) and create a new project.
+2. Copy your `Project ID`
+3. Rename `.env.example` to `.env` and paste your `Project ID` as the value for `VITE_PROJECT_ID`
+4. Run `pnpm install` to install dependencies
+5. Run `pnpm run dev` to start the development server
+6. Test it at https://react-wallet.reown.com/
+
+## Resources
+
+- [Reown — Docs](https://docs.reown.com)
+- [Vite — GitHub](https://github.com/vitejs/vite)
+- [Vite — Docs](https://vitejs.dev/guide/)

--- a/javascript/javascript-solana/.env.example
+++ b/javascript/javascript-solana/.env.example
@@ -1,0 +1,1 @@
+VITE_PROJECT_ID=

--- a/javascript/javascript-solana/README.md
+++ b/javascript/javascript-solana/README.md
@@ -1,0 +1,18 @@
+# Reown AppKit Example using Solana (Vite + JavaScript)
+
+This is a [Vite](https://vitejs.dev) project using vanilla JavaScript with the Solana adapter.
+
+## Usage
+
+1. Go to [Reown Dashboard](https://dashboard.reown.com) and create a new project.
+2. Copy your `Project ID`
+3. Rename `.env.example` to `.env` and paste your `Project ID` as the value for `VITE_PROJECT_ID`
+4. Run `pnpm install` to install dependencies
+5. Run `pnpm run dev` to start the development server
+6. Test it at https://react-wallet.reown.com/
+
+## Resources
+
+- [Reown — Docs](https://docs.reown.com)
+- [Vite — GitHub](https://github.com/vitejs/vite)
+- [Vite — Docs](https://vitejs.dev/guide/)

--- a/javascript/javascript-wagmi/.env.example
+++ b/javascript/javascript-wagmi/.env.example
@@ -1,0 +1,1 @@
+VITE_PROJECT_ID=

--- a/javascript/javascript-wagmi/README.md
+++ b/javascript/javascript-wagmi/README.md
@@ -1,0 +1,18 @@
+# Reown AppKit Example using wagmi (Vite + JavaScript)
+
+This is a [Vite](https://vitejs.dev) project using vanilla JavaScript with the wagmi adapter for multi-chain EVM support.
+
+## Usage
+
+1. Go to [Reown Dashboard](https://dashboard.reown.com) and create a new project.
+2. Copy your `Project ID`
+3. Rename `.env.example` to `.env` and paste your `Project ID` as the value for `VITE_PROJECT_ID`
+4. Run `pnpm install` to install dependencies
+5. Run `pnpm run dev` to start the development server
+6. Test it at https://react-wallet.reown.com/
+
+## Resources
+
+- [Reown — Docs](https://docs.reown.com)
+- [Vite — GitHub](https://github.com/vitejs/vite)
+- [Vite — Docs](https://vitejs.dev/guide/)

--- a/nextjs/next-siwe-next-auth/README.md
+++ b/nextjs/next-siwe-next-auth/README.md
@@ -4,7 +4,7 @@ A Minimal demo using React so developers can work on their integration with Wall
 
 1. Install dependencies in the frontend: `pnpm install`
 
-2. Create and complete the .env.local file with your Project Id from http://cloud.reown.com
+2. Create and complete the .env.local file with your Project Id from https://dashboard.reown.com/
 
 ```
 NEXT_PUBLIC_PROJECT_ID=...

--- a/react/react-siwe-server-example/.env.test
+++ b/react/react-siwe-server-example/.env.test
@@ -1,1 +1,1 @@
-VITE_PROJECT_ID=<your-project-id-from-cloud.reown.com>
+VITE_PROJECT_ID=<your-project-id-from-dashboard.reown.com>

--- a/react/react-siwe-server-example/README.md
+++ b/react/react-siwe-server-example/README.md
@@ -4,7 +4,7 @@ A Minimal demo using React so developers can work on their integration with Wall
 
 1. Install dependencies in the frontend: `pnpm install`
 
-2. Create and complete the .env.local file with your Project Id from http://cloud.reown.com
+2. Create and complete the .env.local file with your Project Id from https://dashboard.reown.com/
 
 ```
 VITE_PROJECT_ID=...

--- a/vue/vue-universal-connector/README.md
+++ b/vue/vue-universal-connector/README.md
@@ -27,7 +27,7 @@ This is a [Vite](https://vitejs.dev) project together with Vue that demonstrates
 ## Resources
 
 - [Reown — Docs](https://docs.reown.com)
-- [Universal Connector — Docs](https://docs.reown.com/appkit/universal-connector)
+- [Universal Connector — Docs](https://docs.reown.com/appkit/recipes/universal-connector)
 - [Vite — GitHub](https://github.com/vitejs/vite)
 - [Vite — Docs](https://vitejs.dev/guide/)
 - [Vue - Docs](https://vuejs.org/guide/introduction)


### PR DESCRIPTION
Fixes stale documentation that had drifted out of sync with the live Reown docs and the repo's own contents.

- **Dead `docs.reown.com` links:** repointed Universal Authentication → `authentication/socials` and Vue universal-connector → `recipes/universal-connector`, and removed the deprecated Smart Sessions and Notifications feature bullets (both now 404).
- **Broken example references:** removed the AppKit Pay row from the Examples table and the non-existent `react-wagmi-appkit-pay` entry from the Structure tree (dead demo + missing directory).
- **`cloud.reown.com` → `dashboard.reown.com`:** updated the old dashboard domain across two example READMEs, `AGENTS.md`, and a `.env.test` placeholder.
- **JavaScript examples:** added READMEs (matching the existing JS example template) and `.env.example` (`VITE_PROJECT_ID=`) files to all JavaScript examples, which previously lacked them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)