### PR TITLE
chore: remove redundant @wagmi/core dependency and overrides

### DIFF
--- a/javascript/javascript-multichain/package.json
+++ b/javascript/javascript-multichain/package.json
@@ -12,7 +12,6 @@
     "@reown/appkit-adapter-wagmi": "1.8.21",
     "@solana/web3.js": "^1.95.8",
     "@wagmi/connectors": "^6.2.0",
-    "@wagmi/core": "^2.21.2",
     "viem": "^2.47.0",
     "wagmi": "^2.13.3"
   },

--- a/javascript/javascript-wagmi/package.json
+++ b/javascript/javascript-wagmi/package.json
@@ -10,7 +10,6 @@
     "@reown/appkit": "1.8.21",
     "@reown/appkit-adapter-wagmi": "1.8.21",
     "@wagmi/connectors": "^6.2.0",
-    "@wagmi/core": "^2.22.0",
     "viem": "^2.47.0",
     "wagmi": "^2.18.0"
   },

--- a/react/react-wagmi/package.json
+++ b/react/react-wagmi/package.json
@@ -14,17 +14,10 @@
     "@reown/appkit-adapter-wagmi": "1.8.21",
     "@tanstack/react-query": "5.90.3",
     "@wagmi/connectors": "6.2.0",
-    "@wagmi/core": "2.22.1",
     "react": "19.2.1",
     "react-dom": "19.2.1",
     "viem": "2.47.0",
     "wagmi": "2.19.5"
-  },
-  "overrides": {
-    "@wagmi/connectors": "6.2.0",
-    "@wagmi/core": "2.22.1",
-    "wagmi": "2.19.5",
-    "viem": "2.47.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",


### PR DESCRIPTION
Removes the redundant `@wagmi/core` dependency from the `javascript-multichain`, `javascript-wagmi`, and `react-wagmi` examples, since it is already provided transitively by `wagmi`. Also drops the now-unnecessary `overrides` block from `react-wagmi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)