### PR TITLE
feat: sign and broadcast a USDT transfer in the React Tron example

### DIFF
--- a/react/react-tron/README.md
+++ b/react/react-tron/README.md
@@ -10,6 +10,50 @@ This is a [Vite](https://vitejs.dev) project together with React.
 4. Run `pnpm install` to install dependencies
 5. Run `pnpm run dev` to start the development server
 
+## Actions
+
+| Button | What it does |
+|---|---|
+| `Switch` | Toggle between TRON mainnet and Shasta testnet |
+| `Sign msg` | `walletProvider.signMessage(...)` |
+| `Send tx` | Native TRX transfer via `walletProvider.sendTransaction(...)` |
+| `Send USDT` | TRC-20 `transfer(address,uint256)` signed with `tron_signTransaction` |
+| `Get Balance` | `useAppKitBalance().fetchBalance()` |
+
+### Send tx
+
+Sends 0.001 TRX to `RECIPIENT_ADDRESS` in `src/config/index.tsx`, which defaults to the TRON black
+hole address — replace it with an address you control if you want the TRX back. TRON rejects native
+transfers where the sender and the recipient are the same account, so this action needs a real
+counterparty.
+
+### Send USDT
+
+AppKit's typed `sendTransaction` only moves native TRX, so a TRC-20 transfer takes three steps:
+
+1. **Build** the unsigned `TriggerSmartContract` transaction with
+   `tronWeb.transactionBuilder.triggerSmartContract(...)`.
+2. **Sign** it with the wallet. Over WalletConnect this is the `tron_signTransaction` RPC method;
+   the injected TronLink connector doesn't implement it and exposes `tron_sendTransaction` instead,
+   which — despite the name — signs without broadcasting. `signTransaction()` in
+   `src/components/ActionButtonList.tsx` picks the right one based on the connector type.
+3. **Broadcast** it with `tronWeb.trx.sendRawTransaction(signedTx)`.
+
+This **broadcasts a real transaction**. It transfers 0.01 USDT to the connected account itself, so no
+USDT actually leaves the wallet, but the account still pays the energy/bandwidth fee (roughly 13–27
+TRX if you have no staked energy). USDT has 6 decimals, so 0.01 USDT is `10_000` in the token's
+smallest unit.
+
+The USDT contract address per network is in `src/config/index.tsx`:
+
+| Network | USDT contract |
+|---|---|
+| TRON mainnet | `TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t` |
+| Shasta testnet | `TG3XXyExBkPp9nzdajDZsozEu4BkaSJozs` |
+
+To try it on Shasta, get test funds from the `TronFAQBot` faucet in the [TRON Discord](https://discord.gg/tron):
+`!shasta` for TRX and `!shasta_usdt <your address>` for USDT.
+
 ## Resources
 
 - [Reown — Docs](https://docs.reown.com)

--- a/react/react-tron/package.json
+++ b/react/react-tron/package.json
@@ -12,9 +12,11 @@
   "dependencies": {
     "@reown/appkit": "1.8.21",
     "@reown/appkit-adapter-tron": "1.8.21",
+    "@tronweb3/tronwallet-adapter-metamask-tron": "^1.1.1",
     "@tronweb3/tronwallet-adapter-tronlink": "1.1.13",
     "react": "19.2.1",
-    "react-dom": "19.2.1"
+    "react-dom": "19.2.1",
+    "tronweb": "6.4.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",
@@ -27,6 +29,7 @@
     "globals": "^15.9.0",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^7.2.7"
+    "vite": "^7.2.7",
+    "vite-plugin-node-polyfills": "^0.24.0"
   }
 }

--- a/react/react-tron/src/App.tsx
+++ b/react/react-tron/src/App.tsx
@@ -1,7 +1,6 @@
 import { createAppKit } from '@reown/appkit/react'
-import { tronMainnet, tronShastaTestnet } from '@reown/appkit/networks'
 import { useState } from 'react'
-import { metadata, projectId, tronAdapter } from './config'
+import { metadata, networks, projectId, tronAdapter } from './config'
 import { ActionButtonList } from './components/ActionButtonList'
 import { InfoList } from './components/InfoList'
 
@@ -12,7 +11,7 @@ createAppKit({
   projectId,
   metadata,
   themeMode: 'light',
-  networks: [tronMainnet, tronShastaTestnet],
+  networks,
   adapters: [tronAdapter],
   features: {
     analytics: true // Optional - defaults to your Cloud configuration
@@ -26,9 +25,19 @@ export function App() {
   const [transactionHash, setTransactionHash] = useState<string | undefined>(undefined);
   const [signedMsg, setSignedMsg] = useState('');
   const [balance, setBalance] = useState('');
+  const [usdtHash, setUsdtHash] = useState('');
+  const [error, setError] = useState('');
 
   const receiveHash = (hash: string) => {
     setTransactionHash(hash); // Update the state with the transaction hash
+  };
+
+  const receiveUsdtHash = (hash: string) => {
+    setUsdtHash(hash); // Update the state with the USDT transfer hash
+  };
+
+  const receiveError = (error: string) => {
+    setError(error)
   };
 
   const receiveSignedMsg = (signedMsg: string) => {
@@ -44,14 +53,14 @@ export function App() {
       <img src="/reown.svg" alt="Reown" style={{ width: '150px', height: '150px' }} />
       <h2>Reown AppKit + TRON</h2>
       <appkit-button />
-      <ActionButtonList sendHash={receiveHash} sendSignMsg={receiveSignedMsg} sendBalance={receivebalance}/>
+      <ActionButtonList sendHash={receiveHash} sendSignMsg={receiveSignedMsg} sendBalance={receivebalance} sendUsdtHash={receiveUsdtHash} sendError={receiveError}/>
       <div className="advice">
         <p>
           This projectId only works on localhost. <br/>
           Go to <a href="https://dashboard.reown.com" target="_blank" className="link-button" rel="Reown Dashboard">Reown Dashboard</a> to get your own.
         </p>
       </div>
-      <InfoList hash={transactionHash} signedMsg={signedMsg} balance={balance}/>
+      <InfoList hash={transactionHash} signedMsg={signedMsg} balance={balance} usdtHash={usdtHash} error={error}/>
     </div>
   )
 }

--- a/react/react-tron/src/components/ActionButtonList.tsx
+++ b/react/react-tron/src/components/ActionButtonList.tsx
@@ -7,15 +7,53 @@ import {
   useAppKitBalance
 } from '@reown/appkit/react'
 import type { TronConnector } from '@reown/appkit-adapter-tron'
-import { networks } from '../config'
+import { TronWeb, type Types } from 'tronweb'
+import { networks, RECIPIENT_ADDRESS, USDT_ADDRESS, USDT_AMOUNT } from '../config'
 
 interface ActionButtonListProps {
   sendHash: (hash: string) => void;
   sendSignMsg: (hash: string) => void;
   sendBalance: (balance: string) => void;
+  sendUsdtHash: (hash: string) => void;
+  sendError: (error: string) => void;
 }
 
-export const ActionButtonList = ({ sendHash, sendSignMsg, sendBalance }: ActionButtonListProps) => {
+// The WalletConnect connector keeps the UniversalProvider on a public `provider` field, but it is
+// not part of the TronConnector type - this is the little bit of it we need.
+type WalletConnectProvider = {
+  request: <T>(args: { method: string; params: unknown }, chainId: string) => Promise<T>
+}
+
+// Ask the connected wallet to sign an already built transaction.
+async function signTransaction(
+  walletProvider: TronConnector,
+  address: string,
+  transaction: Types.Transaction,
+  caipNetworkId: string
+) {
+  // TronLink (injected) does not implement `tron_signTransaction`. Its `tron_sendTransaction` maps
+  // to the wallet adapter's signTransaction, so despite the name it signs without broadcasting.
+  if (walletProvider.type === 'INJECTED') {
+    return walletProvider.request<Types.SignedTransaction>({
+      method: 'tron_sendTransaction',
+      params: { transaction }
+    })
+  }
+
+  // For WalletConnect we go through the UniversalProvider directly, because
+  // TronWalletConnectConnector.request() delegates to a method that does not exist in appkit 1.8.21.
+  const { provider } = walletProvider as unknown as { provider: WalletConnectProvider }
+
+  return provider.request<Types.SignedTransaction>(
+    {
+      method: 'tron_signTransaction',
+      params: { address, transaction }
+    },
+    caipNetworkId
+  )
+}
+
+export const ActionButtonList = ({ sendHash, sendSignMsg, sendBalance, sendUsdtHash, sendError }: ActionButtonListProps) => {
     const { disconnect } = useDisconnect();
     const { open } = useAppKit();
     const { switchNetwork, caipNetwork } = useAppKitNetwork();
@@ -23,13 +61,13 @@ export const ActionButtonList = ({ sendHash, sendSignMsg, sendBalance }: ActionB
     const { walletProvider } = useAppKitProvider<TronConnector>('tron')
     const { fetchBalance } = useAppKitBalance()
 
-    // function to send a tx (self-transfer of 1000 SUN = 0.001 TRX)
+    // function to send a tx (1000 SUN = 0.001 TRX)
     const handleSendTx = async () => {
       if (!walletProvider || !address) throw Error('user is disconnected');
 
       const hash = await walletProvider.sendTransaction({
         from: address,
-        to: address,
+        to: RECIPIENT_ADDRESS,
         value: '1000'
       })
 
@@ -46,6 +84,44 @@ export const ActionButtonList = ({ sendHash, sendSignMsg, sendBalance }: ActionB
       })
 
       sendSignMsg(sig);
+    }
+
+    // function to transfer 0.01 USDT (TRC-20) to yourself. AppKit's typed `sendTransaction` only
+    // moves native TRX, so the contract call is built with tronweb, signed by the wallet through
+    // `tron_signTransaction`, and broadcast against the TRON node.
+    const handleSendUsdt = async () => {
+      try {
+        sendError('')
+
+        if (!walletProvider || !address || !caipNetwork) throw Error('user is disconnected')
+
+        const contractAddress = USDT_ADDRESS[caipNetwork.id]
+        if (!contractAddress) throw Error(`USDT is not available on ${caipNetwork.name}`)
+
+        const tronWeb = new TronWeb({ fullHost: caipNetwork.rpcUrls.chainDefault.http[0] })
+        tronWeb.setAddress(address)
+
+        // build the unsigned TriggerSmartContract transaction. feeLimit is a cap, not a charge.
+        const { transaction } = await tronWeb.transactionBuilder.triggerSmartContract(
+          contractAddress,
+          'transfer(address,uint256)',
+          { feeLimit: 100_000_000, callValue: 0 },
+          [
+            { type: 'address', value: address },
+            { type: 'uint256', value: USDT_AMOUNT }
+          ],
+          address
+        )
+
+        const signedTx = await signTransaction(walletProvider, address, transaction, caipNetwork.caipNetworkId)
+
+        const receipt = await tronWeb.trx.sendRawTransaction(signedTx)
+        if (!receipt.result) throw Error(receipt.message ?? 'Failed to broadcast transaction')
+
+        sendUsdtHash(signedTx.txID)
+      } catch (error) {
+        sendError(error instanceof Error ? error.message : String(error))
+      }
     }
 
     // function to get the balance
@@ -81,6 +157,7 @@ export const ActionButtonList = ({ sendHash, sendSignMsg, sendBalance }: ActionB
               <button onClick={handleSwitchNetwork}>Switch</button>
               <button onClick={handleSignMsg}>Sign msg</button>
               <button onClick={handleSendTx}>Send tx</button>
+              <button onClick={handleSendUsdt}>Send USDT</button>
               <button onClick={handleGetBalance}>Get Balance</button>
             </div>
           </div>

--- a/react/react-tron/src/components/InfoList.tsx
+++ b/react/react-tron/src/components/InfoList.tsx
@@ -4,6 +4,7 @@ import {
     useAppKitTheme,
     useAppKitEvents,
     useAppKitAccount,
+    useAppKitNetwork,
     useWalletInfo
      } from '@reown/appkit/react'
 
@@ -11,14 +12,19 @@ interface InfoListProps {
     hash: string | undefined;
     signedMsg: string;
     balance: string;
+    usdtHash: string;
+    error: string;
 }
 
-export const InfoList = ({ hash, signedMsg, balance }: InfoListProps) => {
+export const InfoList = ({ hash, signedMsg, balance, usdtHash, error }: InfoListProps) => {
     const { themeMode, themeVariables } = useAppKitTheme();
     const state = useAppKitState();
     const {address, caipAddress, isConnected, status, embeddedWalletInfo } = useAppKitAccount();
+    const { caipNetwork } = useAppKitNetwork()
     const events = useAppKitEvents()
     const walletInfo = useWalletInfo()
+
+    const explorerUrl = caipNetwork?.blockExplorers?.default.url
 
     useEffect(() => {
         console.log("Events: ", events);
@@ -26,6 +32,25 @@ export const InfoList = ({ hash, signedMsg, balance }: InfoListProps) => {
 
   return (
     < >
+        {error && (
+        <section>
+            <h2>Error</h2>
+            <pre>
+                {error}<br />
+            </pre>
+        </section>
+        )}
+        {usdtHash && (
+        <section>
+            <h2>Send USDT</h2>
+            <pre>
+                Hash: {usdtHash}<br />
+            </pre>
+            {explorerUrl && (
+                <a href={`${explorerUrl}/#/transaction/${usdtHash}`} target="_blank" rel="noreferrer">View on explorer</a>
+            )}
+        </section>
+        )}
         {balance && (
         <section>
             <h2>Balance: {balance}</h2>

--- a/react/react-tron/src/config/index.tsx
+++ b/react/react-tron/src/config/index.tsx
@@ -2,6 +2,7 @@ import { tronMainnet, tronShastaTestnet } from '@reown/appkit/networks'
 import type { AppKitNetwork } from '@reown/appkit/networks'
 import { TronAdapter } from '@reown/appkit-adapter-tron'
 import { TronLinkAdapter } from '@tronweb3/tronwallet-adapter-tronlink'
+import { MetaMaskAdapter } from '@tronweb3/tronwallet-adapter-metamask-tron'
 
 
 // Get projectId from https://dashboard.reown.com
@@ -21,10 +22,29 @@ export const metadata = {
 
 export const networks: [AppKitNetwork, ...AppKitNetwork[]] = [tronMainnet, tronShastaTestnet]
 
+// USDT (TRC-20) has 6 decimals on every TRON network, but a different address on each one.
+// Shasta USDT can be claimed from the TronFAQBot faucet in the TRON Discord: `!shasta_usdt <address>`
+export const USDT_ADDRESS: Record<string, string> = {
+  [tronMainnet.id]: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+  [tronShastaTestnet.id]: 'TG3XXyExBkPp9nzdajDZsozEu4BkaSJozs'
+}
+
+// 0.01 USDT expressed in the token's smallest unit (10 ** 6)
+export const USDT_AMOUNT = 10_000
+
+// TRON rejects native TRX transfers where the sender and the recipient are the same account, so the
+// "Send tx" action needs a real counterparty. This is the TRON black hole address.
+// NOTE: replace it with an address you control if you want the TRX back.
+export const RECIPIENT_ADDRESS = 'TBPPmZpqXoLUaxNbbDMvCK888doHneEsrD'
+
 // Set up Tron Adapter
 export const tronAdapter = new TronAdapter({
   walletAdapters: [
     new TronLinkAdapter({
+      openUrlWhenWalletNotFound: false,
+      checkTimeout: 3000
+    }),
+    new MetaMaskAdapter({
       openUrlWhenWalletNotFound: false,
       checkTimeout: 3000
     })

--- a/react/react-tron/vite.config.ts
+++ b/react/react-tron/vite.config.ts
@@ -1,9 +1,11 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { nodePolyfills } from 'vite-plugin-node-polyfills'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  // tronweb relies on node built-ins (Buffer, process), so they need to be polyfilled
+  plugins: [react(), nodePolyfills()],
   define: {
     'process.env': {},
   },


### PR DESCRIPTION
Adds a **Send USDT** action to `react/react-tron` that transfers 0.01 USDT (TRC-20) to the connected account — the `TriggerSmartContract` transaction is built with tronweb, signed by the wallet, then broadcast — since AppKit's typed `sendTransaction` only moves native TRX.

Neither Tron connector accepts a plain `tron_signTransaction` request in appkit 1.8.21: the injected TronLink connector throws `Unsupported method` and only accepts `tron_sendTransaction` (which signs without broadcasting), while `TronWalletConnectConnector.request()` delegates to an `internalRequest` method the base `WalletConnectConnector` doesn't define — so the new `signTransaction` helper picks the right path per connector type.

Also registers the MetaMask Tron wallet adapter alongside TronLink, and fixes **Send tx**, which self-transferred TRX from and to the connected account (TRON rejects that outright with `Cannot transfer TRX to yourself`) — it now sends to a configurable `RECIPIENT_ADDRESS`.

Supporting changes: errors and the USDT tx hash (with an explorer link) are surfaced in `InfoList`, `tronweb` + `vite-plugin-node-polyfills` are added, `createAppKit` uses the shared `networks` export instead of an inline copy, and the README documents each action plus the per-network USDT contract addresses.

Verified with `tsc -b`, `eslint`, and `vite build`; the tronweb call was checked against both networks to confirm it produces selector `a9059cbb` with amount `10000` (USDT has 6 decimals). The wallet signing and broadcast steps still need a manual run with a funded account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)