### PR TITLE
feat: use Robinhood Chain (4663) in react-wagmi example

### DIFF
--- a/react/react-wagmi/package.json
+++ b/react/react-wagmi/package.json
@@ -10,13 +10,13 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@reown/appkit": "1.8.21",
-    "@reown/appkit-adapter-wagmi": "1.8.21",
+    "@reown/appkit": "1.8.23",
+    "@reown/appkit-adapter-wagmi": "1.8.23",
     "@tanstack/react-query": "5.90.3",
     "@wagmi/connectors": "6.2.0",
     "react": "19.2.1",
     "react-dom": "19.2.1",
-    "viem": "2.47.0",
+    "viem": "2.55.19",
     "wagmi": "2.19.5"
   },
   "devDependencies": {

--- a/react/react-wagmi/src/config/index.tsx
+++ b/react/react-wagmi/src/config/index.tsx
@@ -1,5 +1,5 @@
 import { WagmiAdapter } from '@reown/appkit-adapter-wagmi'
-import { mainnet, arbitrum, sepolia } from '@reown/appkit/networks'
+import { defineChain } from '@reown/appkit/networks'
 import type { AppKitNetwork } from '@reown/appkit/networks'
 
 // Get projectId from https://dashboard.reown.com
@@ -16,8 +16,33 @@ export const metadata = {
     icons: ['https://avatars.githubusercontent.com/u/179229932']
   }
 
+// Robinhood Chain is not shipped with viem/@reown/appkit networks, so we declare it
+// as a custom network -> https://docs.reown.com/appkit/react/core/custom-networks
+export const robinhoodChain = defineChain({
+  id: 4663,
+  caipNetworkId: 'eip155:4663',
+  chainNamespace: 'eip155',
+  name: 'Robinhood Chain',
+  nativeCurrency: {
+    name: 'Ether',
+    symbol: 'ETH',
+    decimals: 18
+  },
+  rpcUrls: {
+    default: {
+      http: ['https://rpc.mainnet.chain.robinhood.com']
+    }
+  },
+  blockExplorers: {
+    default: {
+      name: 'Blockscout',
+      url: 'https://robinhoodchain.blockscout.com'
+    }
+  }
+})
+
 // for custom networks visit -> https://docs.reown.com/appkit/react/core/custom-networks
-export const networks = [mainnet, arbitrum, sepolia] as [AppKitNetwork, ...AppKitNetwork[]]
+export const networks = [robinhoodChain] as unknown as [AppKitNetwork, ...AppKitNetwork[]]
 
 //Set up the Wagmi Adapter (Config)
 export const wagmiAdapter = new WagmiAdapter({

--- a/react/react-wagmi/src/config/index.tsx
+++ b/react/react-wagmi/src/config/index.tsx
@@ -42,7 +42,7 @@ export const robinhoodChain = defineChain({
 })
 
 // for custom networks visit -> https://docs.reown.com/appkit/react/core/custom-networks
-export const networks = [robinhoodChain] as unknown as [AppKitNetwork, ...AppKitNetwork[]]
+export const networks = [robinhoodChain] as [AppKitNetwork, ...AppKitNetwork[]]
 
 //Set up the Wagmi Adapter (Config)
 export const wagmiAdapter = new WagmiAdapter({


### PR DESCRIPTION
Robinhood Chain (id 4663) is not shipped in `viem/chains`, which is what `@reown/appkit/networks` re-exports, so it is declared as a custom network with AppKit's `defineChain` (RPC, Blockscout explorer and ETH native currency from the ethereum-lists chain registry). The react-wagmi example's `networks` array now uses that chain instead of mainnet/arbitrum/sepolia. Also bumps `@reown/appkit` and `@reown/appkit-adapter-wagmi` to 1.8.23 and `viem` to 2.55.19. Verified with `pnpm build` (`tsc -b` + `vite build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)